### PR TITLE
Trim `-rc1` from `RxNuke iOS` CFBundleShortVersionString

### DIFF
--- a/Supporting Files/Info.plist
+++ b/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5-rc1</string>
+	<string>0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
I suspect that you forgot to trim `-rc1` from CFBundleShortVersionString 🤔 