### PR TITLE
Update RxNuke.swift

### DIFF
--- a/Source/RxNuke.swift
+++ b/Source/RxNuke.swift
@@ -11,22 +11,25 @@ import UIKit
 import AppKit
 #endif
 
-public extension Nuke.ImagePipeline {
-    public func loadImage(with url: URL) -> RxSwift.Single<Nuke.ImageResponse> {
-        return loadImage(with: ImageRequest(url: url))
+extension ImagePipeline: ReactiveCompatible {}
+
+public extension Reactive where Base: ImagePipeline {
+
+    public func loadImage(with url: URL) -> Single<ImageResponse> {
+        return self.loadImage(with: ImageRequest(url: url))
     }
 
-    public func loadImage(with request: Nuke.ImageRequest) -> RxSwift.Single<Nuke.ImageResponse> {
-        return Single<Nuke.ImageResponse>.create { observer in
+    public func loadImage(with request: ImageRequest) -> Single<ImageResponse> {
+        return Single<ImageResponse>.create { single in
             if let image = self.cachedResponse(for: request) {
-                observer(.success(image)) // return syncrhonously
+                single(.success(image)) // return synchronously
                 return Disposables.create() // nop
             } else {
-                let task = self.loadImage(with: request) { response, error in
+                let task = self.base.loadImage(with: request) { response, error in
                     if let response = response {
-                        observer(.success(response))
+                        single(.success(response))
                     } else {
-                        observer(.error(error ?? ImagePipeline.Error.processingFailed)) // error always non-nil
+                        single(.error(error ?? ImagePipeline.Error.processingFailed)) // error always non-nil
                     }
                 }
                 return Disposables.create { task.cancel() }
@@ -34,8 +37,8 @@ public extension Nuke.ImagePipeline {
         }
     }
 
-    private func cachedResponse(for request: Nuke.ImageRequest) -> Nuke.ImageResponse? {
+    private func cachedResponse(for request: ImageRequest) -> ImageResponse? {
         guard request.memoryCacheOptions.isReadAllowed else { return nil }
-        return configuration.imageCache?.cachedResponse(for: request)
+        return base.configuration.imageCache?.cachedResponse(for: request)
     }
 }


### PR DESCRIPTION
In this PR, I am suggesting to access Nuke's reactive extensions by making `ImagePipeline` to conform with `ReactiveCompatible`.

**E.g: Doing this**
```swift 
pipeline.rx.loadImage(with: lowResUrl)
```

**Instead of this**

```swift 
pipeline.loadImage(with: lowResUrl)
```
I think, this separation makes it easier to understand whenever the basic methods or reactive ones are used. Additionally, I have seen a lot of libraries that use this pattern for creating reactive extensions.