### PR TITLE
Update RxNuke

### DIFF
--- a/Source/RxNuke.swift
+++ b/Source/RxNuke.swift
@@ -25,13 +25,13 @@ public extension Reactive where Base: ImagePipeline {
         return self.load(with: request)
     }
     
-    /// Loads an image with a given url. Emits an ImageResponse value otherwise
+    /// Loads an image with a given url. Emits ImageResponse otherwise
     /// dismisses errors and completes the sequence.
     public func loadImage(with url: URL) -> Observable<ImageResponse> {
         return self.load(with: ImageRequest(url: url)).orEmpty()
     }
 
-    /// Loads an image with a given request.  Emits an ImageResponse value otherwise
+    /// Loads an image with a given request. Emits ImageResponse otherwise
     /// dismisses errors and completes the sequence.
     public func loadImage(with request: ImageRequest) -> Observable<ImageResponse> {
         return self.load(with: request).orEmpty()
@@ -40,7 +40,7 @@ public extension Reactive where Base: ImagePipeline {
     private func load(with imageRequest: ImageRequest) -> Single<ImageResponse> {
         return Single<ImageResponse>.create { single in
             if let image = self.cachedResponse(for: imageRequest) {
-                single(.success(image)) // return syncrhonously
+                single(.success(image)) // return synchronously
                 return Disposables.create() // nop
             } else {
                 let task = self.base.loadImage(with: imageRequest) { response, error in

--- a/Source/RxNuke.swift
+++ b/Source/RxNuke.swift
@@ -62,9 +62,10 @@ public extension Reactive where Base: ImagePipeline {
 }
 
 private extension PrimitiveSequence where Trait == SingleTrait {
+    /// Dismiss errors and complete the sequence instead
+    /// - returns: An observable sequence that never errors.
     func orEmpty() -> Observable<Element> {
-        return asObservable()
-            .catchError { _ in .empty() }
+        return asObservable().catchError { _ in .empty() }
     }
 }
 


### PR DESCRIPTION
Hi @kean 

In this PR, I am including the `orEmpty()` operator, but in a private extension. This operator is used in two observables which dismisses the errors and completes the sequence. Additionally I updated the comments for each public method.

Let me know your opinion. 😊