### PR TITLE
migrate to swift 5

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "kean/Nuke" "7.2.1"
-github "ReactiveX/RxSwift" "4.2.0"
+github "ReactiveX/RxSwift" "4.5.0"
+github "kean/Nuke" "7.5.2"

--- a/RxNuke.xcodeproj/project.pbxproj
+++ b/RxNuke.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0CC1FD51209EF1B1004162D6 /* RxNuke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7F4BFD1EEC4DF4000EA6C7 /* RxNuke.swift */; };
 		0CC1FD52209EF1B2004162D6 /* RxNuke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7F4BFD1EEC4DF4000EA6C7 /* RxNuke.swift */; };
 		0CC1FD53209EF1B2004162D6 /* RxNuke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7F4BFD1EEC4DF4000EA6C7 /* RxNuke.swift */; };
+		82A5DEB72255D0DD00BE809A /* RxNuke.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C6A2ED21BDAA3C700765F15 /* RxNuke.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,6 +64,7 @@
 			files = (
 				0C94CC311EEC539B0025B968 /* RxSwift.framework in Frameworks */,
 				0C94CC301EEC539B0025B968 /* Nuke.framework in Frameworks */,
+				82A5DEB72255D0DD00BE809A /* RxNuke.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -243,7 +245,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Alexander Grebenyuk";
 				TargetAttributes = {
 					0C6A2ED11BDAA3C700765F15 = {
@@ -252,7 +254,7 @@
 					};
 					0C8D254E1BCC33730029A841 = {
 						CreatedOnToolsVersion = 7.0.1;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 1020;
 					};
 					0CD205BE1BCC688800B88F70 = {
 						CreatedOnToolsVersion = 7.0.1;
@@ -266,10 +268,11 @@
 			};
 			buildConfigurationList = 0C8D25491BCC33730029A841 /* Build configuration list for PBXProject "RxNuke" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 0C8D25451BCC33730029A841;
 			productRefGroup = 0C8D25501BCC33730029A841 /* Products */;
@@ -407,6 +410,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -466,6 +470,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -537,7 +542,7 @@
 				PRODUCT_NAME = RxNuke;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -562,7 +567,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.RxNuke;
 				PRODUCT_NAME = RxNuke;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -588,7 +593,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -614,7 +619,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};

--- a/RxNuke.xcodeproj/project.pbxproj
+++ b/RxNuke.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 0C8D25451BCC33730029A841;
@@ -588,7 +589,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Debug;
 		};
@@ -614,7 +615,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Release;
 		};

--- a/RxNuke.xcodeproj/xcshareddata/xcschemes/RxNuke iOS.xcscheme
+++ b/RxNuke.xcodeproj/xcshareddata/xcschemes/RxNuke iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RxNuke.xcodeproj/xcshareddata/xcschemes/RxNuke macOS.xcscheme
+++ b/RxNuke.xcodeproj/xcshareddata/xcschemes/RxNuke macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RxNuke.xcodeproj/xcshareddata/xcschemes/RxNuke tvOS.xcscheme
+++ b/RxNuke.xcodeproj/xcshareddata/xcschemes/RxNuke tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RxNuke.xcodeproj/xcshareddata/xcschemes/RxNuke watchOS.xcscheme
+++ b/RxNuke.xcodeproj/xcshareddata/xcschemes/RxNuke watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/RxNuke.swift
+++ b/Source/RxNuke.swift
@@ -16,13 +16,13 @@ extension ImagePipeline: ReactiveCompatible {}
 public extension Reactive where Base: ImagePipeline {
     /// Loads an image with a given url. Emits the value synchronously if the
     /// image was found in memory cache.
-    public func loadImage(with url: URL) -> Single<ImageResponse> {
+  func loadImage(with url: URL) -> Single<ImageResponse> {
         return self.loadImage(with: ImageRequest(url: url))
     }
 
     /// Loads an image with a given request. Emits the value synchronously if the
     /// image was found in memory cache.
-    public func loadImage(with request: ImageRequest) -> Single<ImageResponse> {
+  func loadImage(with request: ImageRequest) -> Single<ImageResponse> {
         return Single<ImageResponse>.create { single in
             if let image = self.cachedResponse(for: request) {
                 single(.success(image)) // return synchronously


### PR DESCRIPTION
I did migration for swift 5
I update the WATCHOS_DEVELOPMENT_TARGET to 3.0 from 2.0 because RxSwift said so.
```
RxNuke.swift:6:8: error: compiling for watchOS 2.0, but module 'RxSwift' has a minimum deployment target of watchOS 3.0
```