### PR TITLE
Compatible to RxSwift 6.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "kean/Nuke" ~> 9.0.0
-github "ReactiveX/RxSwift" ~> 5.1.0
+github "ReactiveX/RxSwift" ~> 6.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "ReactiveX/RxSwift" "5.1.1"
+github "ReactiveX/RxSwift" "6.0.0"
 github "kean/Nuke" "9.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "ReactiveX/RxSwift" "5.1.1"
-github "kean/Nuke" "8.4.1"
+github "kean/Nuke" "9.0.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
-          "version": "5.1.1"
+          "revision": "c8742ed97fc2f0c015a5ea5eddefb064cd7532d2",
+          "version": "6.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/ReactiveX/RxSwift.git",
-            from: "5.1.0"
+            from: "6.0.0"
         )
     ],
     targets: [

--- a/RxNuke.podspec
+++ b/RxNuke.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
     s.module_name = "RxNuke"
 
     s.dependency 'Nuke', '~> 9.0'
-    s.dependency 'RxSwift', '~> 5.1.0'
+    s.dependency 'RxSwift', '~> 6.0.0'
 
     s.source_files  = 'Source/**/*'
 end

--- a/Source/RxNuke.swift
+++ b/Source/RxNuke.swift
@@ -28,14 +28,14 @@ public extension Reactive where Base: ImagePipeline {
                 single(.success(ImageResponse(container: image))) // return synchronously
                 return Disposables.create() // nop
             } else {
-                let task = self.base.loadImage(with: request) { result in
+                let task = self.base.loadImage(with: request, completion: { result in
                     switch result {
                     case let .success(response):
                         single(.success(response))
                     case let .failure(error):
-                        single(.error(error))
+                        single(.failure(error))
                     }
-                }
+                })
                 return Disposables.create { task.cancel() }
             }
         }


### PR DESCRIPTION
- Upgrade to [RxSwift 6.0](https://github.com/ReactiveX/RxSwift/releases/6.0.0)
  - Modify `RxNuke.podspec`
  - Modify `Cartfile` & `Cartfile.resolved`
  - Modify `Package.swift` & `Package.resolved`
  - `SingleEvent` is now simply `Result<Element, Swift.Error>` and methods changed accordingly.
- Edit `Nuke` version in `Cartfile.resolved`

Best Regard,